### PR TITLE
Weapon contraband tweaks

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -1214,7 +1214,7 @@
   parent: IDCardStandard
   id: CentcomIDCard
   name: command officer ID card
-  suffix: ERT # Lust add
+  suffix: Central Command # Lust add
   components:
   # Sunrise-Start
   - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -1214,6 +1214,7 @@
   parent: IDCardStandard
   id: CentcomIDCard
   name: command officer ID card
+  suffix: ERT # Lust add
   components:
   # Sunrise-Start
   - type: Sprite
@@ -1236,6 +1237,7 @@
   parent: IDCardStandard
   id: ERTLeaderIDCard
   name: ERT leader ID card
+  suffix: ERT # Lust add
   components:
   # Sunrise-Start
   - type: Sprite
@@ -1257,6 +1259,7 @@
   parent: IDCardStandard
   id: ERTChaplainIDCard
   name: ERT chaplain ID card
+  suffix: ERT # Lust add
   components:
   # Sunrise-Start
   - type: Sprite
@@ -1278,6 +1281,7 @@
   parent: IDCardStandard
   id: ERTEngineerIDCard
   name: ERT engineer ID card
+  suffix: ERT # Lust add
   components:
   # Sunrise-Start
   - type: Sprite
@@ -1299,6 +1303,7 @@
   parent: IDCardStandard
   id: ERTJanitorIDCard
   name: ERT janitor ID card
+  suffix: ERT # Lust add
   components:
   # Sunrise-Start
   - type: Sprite
@@ -1320,6 +1325,7 @@
   parent: IDCardStandard
   id: ERTMedicIDCard
   name: ERT medic ID card
+  suffix: ERT # Lust add
   components:
   # Sunrise-Start
   - type: Sprite
@@ -1341,6 +1347,7 @@
   parent: IDCardStandard
   id: ERTSecurityIDCard
   name: ERT security ID card
+  suffix: ERT # Lust add
   components:
   # Sunrise-Start
   - type: Sprite
@@ -1361,6 +1368,7 @@
 - type: entity
   parent: IDCardStandard
   id: CentcomIDCardDeathsquad
+  suffix: Death Squad # Lust add
   name: death squad ID card
   components:
   # Sunrise-Start

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/Weapons/Gun/combat.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/Weapons/Gun/combat.yml
@@ -262,7 +262,7 @@
   name: Ultra AC-2
   description: Mounted carbine, firing LightRifle cartridges.
   suffix: Mech Weapon, Gun, Combat, Rifle
-  parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSecurityScienceContraband ]
+  parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSecurityScienceContraband ] # Lust edit :: BaseSecurityScienceContraband
   components:
   - type: Sprite
     sprite: Objects/Specific/Mech/mecha_equipment.rsi

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/Weapons/Gun/combat.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/Weapons/Gun/combat.yml
@@ -3,7 +3,7 @@
   name: eZ-14 mk2 Heavy pulse rifle
   description: Fires a heavy pulse laser.
   suffix: Mech Weapon, Gun, Combat, Pulse
-  parent: [ BaseMechWeaponRange, CombatMechEquipment ]
+  parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSecurityScienceContraband ] # Lust edit :: BaseSecurityScienceContraband
   components:
   - type: Sprite
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
@@ -26,7 +26,7 @@
   name: ZFI Immolation Beam Gun
   description: A gun for battlemechs, firing high-temperature beams.
   suffix: Mech Weapon, Gun, Combat, Laser
-  parent: [ BaseMechWeaponRange, CombatMechEquipment ]
+  parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSecurityScienceContraband ] # Lust edit :: BaseSecurityScienceContraband
   components:
   - type: Sprite
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
@@ -49,7 +49,7 @@
   name: Mounted Heavy Rifle Gun
   description: A gun for battlemechs, firing Antimaterial bullet.
   suffix: Mech Weapon, Gun, Combat, Anti
-  parent: [ BaseMechWeaponRange, CombatMechEquipment ]
+  parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSecurityScienceContraband ] # Lust edit :: BaseSecurityScienceContraband
   components:
   - type: Sprite
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
@@ -72,7 +72,7 @@
   name: CH-LC "Solaris" laser cannon
   description: An experimental combat mounted laser cannon that causes more damage, but also has a greater cooldown than a "Firedart".
   suffix: Mech Weapon, Gun, Combat, Laser
-  parent: [ BaseMechWeaponRange, CombatMechEquipment ]
+  parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSecurityScienceContraband ] # Lust edit :: BaseSecurityScienceContraband
   components:
   - type: Sprite
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
@@ -101,7 +101,7 @@
   name: CH-PS "Firedart" Laser
   description: The standard combat armament of the mechs is a combat mounted laser.
   suffix: Mech Weapon, Gun, Combat, Laser
-  parent: [ BaseMechWeaponRange, CombatMechEquipment ]
+  parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSecurityScienceContraband ] # Lust edit :: BaseSecurityScienceContraband
   components:
   - type: Sprite
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
@@ -127,7 +127,7 @@
   name: P-X Tesla Cannon
   description: A weapon for combat mechs, firing energy balls, based on the principle of an experimental Tesla engine.
   suffix: Mech Weapon, Gun, Combat, Tesla
-  parent: [ BaseMechWeaponRange, CombatMechEquipment ]
+  parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSecurityScienceContraband ] # Lust edit :: BaseSecurityScienceContraband
   components:
   - type: Sprite
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
@@ -154,7 +154,7 @@
   name: CH-PD Disabler
   description: A non-lethal mounted stun gun that allows you to immobilize intruders.
   suffix: Mech Weapon, Gun, Combat, Disabler
-  parent: [ BaseMechWeaponRange, CombatMechEquipment ]
+  parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSecurityScienceContraband ] # Lust edit :: BaseSecurityScienceContraband
   components:
   - type: Sprite
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
@@ -180,7 +180,7 @@
   name: PBT "Pacifier" Mounted Taser
   description: A mounted non-lethal taser that allows you to stun intruders.
   suffix: Mech Weapon, Gun, Combat, Disabler, admeme
-  parent: [ BaseMechWeaponRange, CombatMechEquipment ]
+  parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSecurityScienceContraband ] # Lust edit :: BaseSecurityScienceContraband
   components:
   - type: Sprite
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
@@ -211,7 +211,7 @@
   name: LBX AC 10 "Scattershot"
   description: A mounted lethal Shotgun.
   suffix: Mech Weapon, Gun, Combat, Shotgun
-  parent: [ BaseMechWeaponRange, CombatMechEquipment ]
+  parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSecurityScienceContraband ] # Lust edit :: BaseSecurityScienceContraband
   components:
   - type: Sprite
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
@@ -234,7 +234,7 @@
   name: FNX-99 "Hades" Carbine
   description: Mounted carbine, firing incendiary cartridges.
   suffix: Mech Weapon, Gun, Combat, Shotgun, Incendiary
-  parent: [ BaseMechWeaponRange, CombatMechEquipment ]
+  parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSecurityScienceContraband ] # Lust edit :: BaseSecurityScienceContraband
   components:
   - type: Sprite
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
@@ -262,7 +262,7 @@
   name: Ultra AC-2
   description: Mounted carbine, firing LightRifle cartridges.
   suffix: Mech Weapon, Gun, Combat, Rifle
-  parent: [ BaseMechWeaponRange, CombatMechEquipment ]
+  parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSecurityScienceContraband ]
   components:
   - type: Sprite
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
@@ -294,7 +294,7 @@
   name: Mk.IV Ion Heavy Cannon
   description: A mounted ion weapon that operates on the same principle as a handheld ion carbine. Extremely effective against synthetics, robots and other mechs.
   suffix: Mech Weapon, Gun, Combat, Ion
-  parent: [ BaseMechWeaponRange, CombatMechEquipment ]
+  parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSecurityScienceContraband ] # Lust edit :: BaseSecurityScienceContraband
   components:
   - type: Sprite
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
@@ -324,7 +324,7 @@
   name: AMLG90
   description: Laser mounted machine gun.
   suffix: Mech Weapon, Gun, Combat, Laser
-  parent: [ BaseMechWeaponRange, CombatMechEquipment ]
+  parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSecurityScienceContraband ] # Lust edit :: BaseSecurityScienceContraband
   components:
   - type: Sprite
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
@@ -361,7 +361,7 @@
   name: S-1 X-Ray Projector
   description: Experimental mech weapon that fires X-rays that pass through obstacles.
   suffix: Mech Weapon, Gun, Combat, X-Ray
-  parent: [ BaseMechWeaponRange, CombatMechEquipment ]
+  parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSecurityScienceContraband ] # Lust edit :: BaseSecurityScienceContraband
   components:
   - type: Sprite
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
@@ -392,7 +392,7 @@
   name: SRM-8 Light Missile Rack
   description: Launches low-explosive breaching missiles designed to explode only when striking a sturdy target.
   suffix: Mech Weapon, Gun, Combat, Light Missile
-  parent: [ BaseMechWeaponRange, CombatMechEquipment ]
+  parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSecurityScienceContraband ] # Lust edit :: BaseSecurityScienceContraband
   components:
   - type: Sprite
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
@@ -432,7 +432,7 @@
   name: BRM-6 Missile Rack
   description: Tubes must be reloaded from the outside.
   suffix: Mech Weapon, Gun, Combat, Missile
-  parent: [ BaseMechWeaponRange, CombatMechEquipment ]
+  parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSecurityScienceContraband ] # Lust edit :: BaseSecurityScienceContraband
   components:
   - type: Sprite
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
@@ -464,7 +464,7 @@
   name: SGL-6 Flashbang Launcher
   description: Launches low-explosive breaching missiles designed to explode only when striking a sturdy target.
   suffix: Mech Weapon, Gun, Combat, Flashbang
-  parent: [ BaseMechWeaponRange, CombatMechEquipment ]
+  parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSecurityScienceContraband ] # Lust edit :: BaseSecurityScienceContraband
   components:
   - type: Sprite
     sprite: Objects/Specific/Mech/mecha_equipment.rsi

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/Weapons/Melee/combat.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/Weapons/Melee/combat.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: WeaponMechChainSword
-  parent: [ BaseMechWeaponMelee, CombatMechEquipment  ]
+  parent: [ BaseMechWeaponMelee, CombatMechEquipment, BaseHighlyIllegalContraband ] # Lust edit :: BaseHighlyIllegalContraband
   name: exosuit chainsword
   suffix: Mech Weapon, Melee, Combat
   description: Equipment for combat exosuits. This is the mechanical chainsword that'll pierce the heavens!

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -112,7 +112,7 @@
 
 - type: entity
   name: L6C ROW
-  id: WeaponLightMachineGunL6C
+  id: [WeaponLightMachineGunL6C, BaseHighlyIllegalContraband] # Lust edit :: BaseHighlyIllegalContraband
   parent: BaseItem
   description: A L6 SAW for use by cyborgs. Creates .30 rifle ammo on the fly from an internal ammo fabricator, which slowly self-charges.
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -112,8 +112,8 @@
 
 - type: entity
   name: L6C ROW
-  id: [WeaponLightMachineGunL6C, BaseHighlyIllegalContraband] # Lust edit :: BaseHighlyIllegalContraband
-  parent: BaseItem
+  id: WeaponLightMachineGunL6C
+  parent: [BaseItem, BaseHighlyIllegalContraband] # Lust edit :: BaseHighlyIllegalContraband
   description: A L6 SAW for use by cyborgs. Creates .30 rifle ammo on the fly from an internal ammo fabricator, which slowly self-charges.
   components:
     - type: Gun

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -162,7 +162,7 @@
 
 - type: entity
   name: multiple rocket launcher
-  parent: BaseWeaponLauncher
+  parent: [BaseWeaponLauncher, BaseHighlyIllegalContraband] # Lust edit :: BaseHighlyIllegalContraband
   id: WeaponLauncherMultipleRocket
   description: A modified ancient rocket-propelled grenade launcher.
   components:
@@ -197,7 +197,7 @@
 
 - type: entity
   name: pirate cannon
-  parent: BaseWeaponLauncher
+  parent: [BaseWeaponLauncher, BaseHighlyIllegalContraband] # Lust edit :: BaseHighlyIllegalContraband
   id: WeaponLauncherPirateCannon
   description: Kaboom!
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -146,7 +146,7 @@
 - type: entity
   name: C-20r ROW #I think ROW stands for Recharging Onboard Weapon so i'm following the L6C's example
   id: WeaponSubMachineGunC20rROW
-  parent: BaseItem
+  parent: [ BaseItem, BaseSyndicateContraband ] # Lust edit :: BaseSyndicateContraband
   description: A burst-fire C-20r submachine gun for use by cyborgs. Creates .35 caliber ammo on the fly from an internal ammo fabricator, which slowly self-charges.
   components:
   - type: Gun

--- a/Resources/Prototypes/_Lust/Arrows/weapons.yml
+++ b/Resources/Prototypes/_Lust/Arrows/weapons.yml
@@ -3,7 +3,7 @@
 - type: entity
   name: The Chainsaw Energy Sword
   suffix: Arrows
-  parent: BaseItem
+  parent: [ BaseItem, BaseHighlyIllegalContraband ]
   id: ChainswordArrows
   description: Technology and ultra-violence in one bottle!
   components:

--- a/Resources/Prototypes/_Lust/Entities/Clothing/Uniforms/Jumpsuit/jumpsuit.yml
+++ b/Resources/Prototypes/_Lust/Entities/Clothing/Uniforms/Jumpsuit/jumpsuit.yml
@@ -110,7 +110,7 @@
     sprite: _Lust/Clothing/Uniforms/Jumpsuit/centcom_uniform_qillu.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: UnsensoredClothingUniformBase
   id: LustClothingUniformJumpsuitStripperSlim
   components:
   - type: Sprite
@@ -119,7 +119,7 @@
     sprite: _Lust/Clothing/Uniforms/stripper_slimsuit.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: UnsensoredClothingUniformBase
   id: LustClothingUniformJumpsuitStripperStarPasties
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Lust/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/_Lust/Entities/Objects/base_contraband.yml
@@ -1,0 +1,7 @@
+- type: entity
+  id: BaseSecurityCentcommContraband
+  parent: BaseRestrictedContraband
+  abstract: true
+  components:
+  - type: Contraband
+    allowedDepartments: [ CentralCommand, Security ]

--- a/Resources/Prototypes/_Lust/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/_Lust/Entities/Objects/base_contraband.yml
@@ -5,10 +5,3 @@
   components:
   - type: Contraband
     allowedDepartments: [ CentralCommand, Security ]
-
-- type: entity
-  id: BaseTSFContraband
-  abstract: true
-  components:
-  - type: Contraband
-    severity: TSF

--- a/Resources/Prototypes/_Lust/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/_Lust/Entities/Objects/base_contraband.yml
@@ -5,3 +5,10 @@
   components:
   - type: Contraband
     allowedDepartments: [ CentralCommand, Security ]
+
+- type: entity
+  id: BaseTSFContraband
+  abstract: true
+  components:
+  - type: Contraband
+    severity: TSF

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -200,7 +200,7 @@
 
 - type: entity
   name: immolator laser gun
-  parent: [BaseWeaponBattery, BaseGunWieldable] # , BaseSecuritySalvageContraband
+  parent: [BaseWeaponBattery, BaseGunWieldable, BaseSecuritySalvageContraband] # Lust edit :: BaseSecuritySalvageContraband # , BaseSecuritySalvageContraband
   id: WeaponLaserImmolator
   description: Favoured by Nanotrasen Security for being cheap and easy to use.
   components:

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Specific/Mech/Weapons/Gun/combat.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Specific/Mech/Weapons/Gun/combat.yml
@@ -2,7 +2,7 @@
   id: WeaponMechCombatVindictor
   name: Mounted MG-100 Vindicator Minigun
   suffix: Mech Weapon, Gun, Combat, Minigun
-  parent: [ BaseMechWeaponRange, CombatMechEquipment ]
+  parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseHighlyIllegalContraband ] # Lust edit :: BaseHighlyIllegalContraband
   components:
   - type: Sprite
     sprite: _Sunrise/Objects/Specific/Mech/mecha_vindictor.rsi
@@ -29,7 +29,7 @@
   name: Mounted Kardashev-Maxim
   description: An ancient heavy machine gun given new life as a mech-mounted gun
   suffix: Mech Weapon, Combat, USSP
-  parent: [ BaseMechWeaponRange, CombatMechEquipment ]
+  parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSyndicateContraband ] # Lust edit :: BaseSyndicateContraband
   components:
   - type: Sprite
     sprite: _Sunrise/Objects/Specific/Mech/mecha_maxim.rsi
@@ -56,7 +56,7 @@
   name: Mounted MG
   description: An ancient heavy machine gun given new life as a mech-mounted gun
   suffix: Mech Weapon, Combat
-  parent: [ BaseMechWeaponRange, CombatMechEquipment ]
+  parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSyndicateContraband ] # Lust edit :: BaseSyndicateContraband
   components:
   - type: Sprite
     sprite: _Sunrise/Objects/Specific/Mech/mecha_mg.rsi
@@ -89,7 +89,7 @@
   name: UVM-31 "Drake"
   description: A heavy weapon of mass destruction developed by Cybersun based on the minigun. now on a sturdy tripod that allows you to fire directly from the MECH!
   suffix: Mech Weapon, Gun, Combat, Laser , Minigun
-  parent: [ BaseMechWeaponRange, CombatMechEquipment ]
+  parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSyndicateContraband ] # Lust edit :: BaseSyndicateContraband
   components:
   - type: Sprite
     sprite: _Sunrise/Objects/Specific/Mech/mecha_uvm31.rsi
@@ -120,7 +120,7 @@
   name: Mounted EXP-220 Duster
   description: An  heavy Auto Cannon as a mech-mounted gun with Frag ammo
   suffix: Mech Weapon, Gun, Combat
-  parent: [ BaseMechWeaponRange, CombatMechEquipment ]
+  parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSyndicateContraband ] # Lust edit :: BaseSyndicateContraband
   components:
   - type: Sprite
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
@@ -157,7 +157,7 @@
   name: mounted "Kord"
   description: Rapid-fire machine gun chambered for 12.7 x 108 mm
   suffix: Mech Weapon, Combat, Kord
-  parent: [ BaseMechWeaponRange, CombatMechEquipment ]
+  parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseHighlyIllegalContraband ] # Lust edit :: BaseHighlyIllegalContraband
   components:
   - type: Sprite
     sprite: _Sunrise/Objects/Specific/Mech/mecha_kord.rsi
@@ -192,7 +192,7 @@
   name: LBX AC 20 "Minotaur"
   description: A mounted Auto-Shotgun.
   suffix: Mech Weapon, Gun, Combat, Shotgun
-  parent: [ BaseMechWeaponRange, CombatMechEquipment ]
+  parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSyndicateContraband ] # Lust edit :: BaseSyndicateContraband
   components:
   - type: Sprite
     scale: 1.1,1.2

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -1,5 +1,5 @@
 - type: entity
-  id: BaseWeaponAutoPowerCell
+  id: [BaseWeaponAutoPowerCell, BaseSecurityContraband] # Lust edit :: BaseSecurityContraband
   parent: BaseItem
   abstract: true
   components:
@@ -287,7 +287,7 @@
 
 - type: entity
   name: EarthGov laser pistol
-  parent: BaseWeaponBatterySmall
+  parent: [BaseWeaponBatterySmall, BaseSecurityContraband] # Lust edit :: BaseSecurityContraband
   id: WeaponEarthGovLaserPistol
   components:
   - type: Gun
@@ -312,7 +312,7 @@
 
 - type: entity
   name: EarthGov laser rifle
-  parent: [BaseWeaponBattery, BaseGunWieldable, BaseGunPulseSound]
+  parent: [BaseWeaponBattery, BaseGunWieldable, BaseGunPulseSound, BaseSecurityContraband] # Lust edit :: BaseSecurityContraband
   id: WeaponEarthGovLaserRifle
   components:
   - type: Sprite
@@ -360,7 +360,7 @@
 
 - type: entity
   name: EarthGov laser carbine
-  parent: [BaseWeaponBattery, BaseGunWieldable, BaseGunPulseSound]
+  parent: [BaseWeaponBattery, BaseGunWieldable, BaseGunPulseSound, BaseSecurityContraband] # Lust edit :: BaseSecurityContraband
   id: WeaponEarthGovLaserCarbine
   components:
   - type: Sprite
@@ -405,7 +405,7 @@
 
 - type: entity
   name: EarthGov laser machine gun
-  parent: [BaseWeaponBattery, BaseGunWieldable, BaseGunPulseSound]
+  parent: [BaseWeaponBattery, BaseGunWieldable, BaseGunPulseSound, BaseSecurityContraband] # Lust edit :: BaseSecurityContraband
   id: WeaponEarthGovLaserMG
   components:
   - type: Sprite
@@ -454,7 +454,7 @@
 
 - type: entity
   name: EarthGov Experemental X-Ray
-  parent: [BaseWeaponBattery, BaseGunPulseSound]
+  parent: [BaseWeaponBattery, BaseGunPulseSound, BaseTSFContraband] # Lust edit :: BaseTSFContraband
   id: WeaponEarthGovXRay
   suffix: SUNRISE14CM
   description: Earth Government Experemental x-ray weapon, it looks like it emits radiation.
@@ -504,7 +504,7 @@
 
 - type: entity
   name: EarthGov heavy laser rifle
-  parent: [BaseWeaponBattery, BaseGunPulseSound]
+  parent: [BaseWeaponBattery, BaseGunPulseSound, BaseSecurityContraband] # Lust edit :: BaseSecurityContraband
   id: WeaponEarthGovLaserSniper
   components:
   - type: Sprite
@@ -701,7 +701,7 @@
     price: 9000
 
 - type: entity
-  parent: BaseWeaponBatterySmall
+  parent: [BaseWeaponBatterySmall, BaseHighlyIllegalContraband] # Lust edit :: BaseHighlyIllegalContraband
   id: WeaponAlien
   name: alien pistol
   components:

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -1,6 +1,6 @@
 - type: entity
-  id: [BaseWeaponAutoPowerCell, BaseSecurityContraband] # Lust edit :: BaseSecurityContraband
-  parent: BaseItem
+  id: BaseWeaponAutoPowerCell
+  parent: [BaseItem, BaseSecurityContraband] # Lust edit :: BaseSecurityContraband
   abstract: true
   components:
   - type: Clothing

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -560,7 +560,7 @@
 
 - type: entity
   name: S-13 «Black mamba»
-  parent: BaseWeaponBattery
+  parent: [ BaseWeaponBattery, BaseSyndicateContraband ] # Lust edit :: BaseSyndicateContraband
   id: WeaponSyndieLaserGun
   description: A modernised Lecter, converted to a plasma energy module.
   components:
@@ -612,7 +612,7 @@
 
 - type: entity
   name: SAM-300
-  parent: BaseWeaponBattery
+  parent: [ ]BaseWeaponBattery, BaseSyndicateContraband ] # Lust edit :: BaseSyndicateContraband
   id: WeaponSyndieLaserPistol
   description: The Syndicate's laser pistol, developed from the NT Captain's pistol.
   components:
@@ -655,7 +655,7 @@
 
 - type: entity
   name: UVL-21 «Vivern»
-  parent: [BaseWeaponBattery, BaseGunPulseSound]
+  parent: [BaseWeaponBattery, BaseGunPulseSound, BaseSyndicateContraband] # Lust edit :: BaseSyndicateContraband
   id: WeaponLaserMinigun
   description: A heavy weapon of mass destruction based on the minigun.
   components:

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -612,7 +612,7 @@
 
 - type: entity
   name: SAM-300
-  parent: [ ]BaseWeaponBattery, BaseSyndicateContraband ] # Lust edit :: BaseSyndicateContraband
+  parent: [ BaseWeaponBattery, BaseSyndicateContraband ] # Lust edit :: BaseSyndicateContraband
   id: WeaponSyndieLaserPistol
   description: The Syndicate's laser pistol, developed from the NT Captain's pistol.
   components:

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/HMGs/hmgs.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/HMGs/hmgs.yml
@@ -3,7 +3,7 @@
   name: MG-100 Vindicator Minigun
   parent: BaseItem
   id: WeaponMinigunMG100
-  categories: [ HideSpawnMenu ]
+  categories: [ HideSpawnMenu, BaseCentcommContraband ] # Lust edit :: BaseCentcommContraband
   components:
   - type: Sprite
     sprite: _Sunrise/Objects/Weapons/Guns/HMGs/minigun/big.rsi
@@ -36,7 +36,7 @@
 
 - type: entity
   id: PowerpackMinigunMG100
-  parent: [ BasePowerpackMG100, ClothingBackpack ]
+  parent: [ BasePowerpackMG100, ClothingBackpack, BaseCentcommContraband ] # Lust edit :: BaseCentcommContraband
   components:
   - type: Item
     size: Ginormous
@@ -115,7 +115,7 @@
 
 - type: entity
   name: DL6902 machine gun
-  parent: BaseItem
+  parent: [ BaseItem, BaseSyndicateContraband ] # Lust edit :: BaseSyndicateContraband
   id: WeaponDL6902PowerPack
   categories: [ HideSpawnMenu ]
   components:
@@ -162,7 +162,7 @@
 - type: entity
   name: DL6902 Powerpack
   id: PowerpackDL6902
-  parent: [ BasePowerpackMG100, ClothingBackpack ]
+  parent: [ BasePowerpackMG100, ClothingBackpack, BaseSyndicateContraband ] # Lust edit :: BaseSyndicateContraband
   components:
   - type: Item
     size: Ginormous

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/HMGs/hmgs.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/HMGs/hmgs.yml
@@ -1,9 +1,9 @@
 
 - type: entity
   name: MG-100 Vindicator Minigun
-  parent: BaseItem
+  parent: [ BaseItem, BaseCentcommContraband ] # Lust edit :: BaseCentcommContraband
   id: WeaponMinigunMG100
-  categories: [ HideSpawnMenu, BaseCentcommContraband ] # Lust edit :: BaseCentcommContraband
+  categories: [ HideSpawnMenu ]
   components:
   - type: Sprite
     sprite: _Sunrise/Objects/Weapons/Guns/HMGs/minigun/big.rsi

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: MG-60
-  parent: BaseWeaponLightMachineGun
+  parent: [BaseWeaponLightMachineGun, BaseSovietContraband] # Lust edit :: BaseSovietContraband
   id: WeaponLightMachineGunMG60
   components:
   - type: Sprite
@@ -98,7 +98,7 @@
 
 - type: entity
   name: RPD
-  parent: BaseWeaponLightMachineGun
+  parent: [BaseWeaponLightMachineGun, BaseSovietContraband] # Lust edit :: BaseSovietContraband
   id: WeaponLightMachineGunRPD
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -169,7 +169,7 @@
 
 - type: entity
   name: MG-342
-  parent: BaseWeaponLightMachineGun
+  parent: [ BaseWeaponLightMachineGun, BaseSecurityCentcommContraband ] # Lust edit :: BaseSecurityCentcommContraband
   id: WeaponMachineGunMG42
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -46,7 +46,7 @@
 
 - type: entity
   name: GL-70
-  parent: [BaseWeaponLauncher, BaseCentCommContraband] # Lust edit :: BaseCentCommContraband
+  parent: [BaseWeaponLauncher, BaseCentcommContraband] # Lust edit :: BaseCentcommContraband
   id: WeaponGrenadeLauncherGL70
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -1,6 +1,6 @@
 ﻿- type: entity
   name: RL-5
-  parent: BaseWeaponLauncher
+  parent: [BaseWeaponLauncher, BaseSecurityContraband] # Lust edit :: BaseSecurityContraband
   id: WeaponLauncherRL5
   components:
   - type: Sprite
@@ -46,7 +46,7 @@
 
 - type: entity
   name: GL-70
-  parent: BaseWeaponLauncher
+  parent: [BaseWeaponLauncher, BaseCentCommContraband] # Lust edit :: BaseCentCommContraband
   id: WeaponGrenadeLauncherGL70
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -53,7 +53,7 @@
 
 - type: entity
   name: combat pistol VP-70
-  parent: BaseWeaponPistolSunrise
+  parent: [ BaseWeaponPistolSunrise, BaseSecurityContraband ] # Lust edit :: BaseSecurityContraband
   id: WeaponPistolVP78
   components:
   - type: Sprite
@@ -99,7 +99,7 @@
 - type: entity
   name: Glock-22 Prison
   description: Manufactured by special order for prison complex security. Semi-automatic firearm chambered in .35 Auto.
-  parent: BaseWeaponPistol
+  parent: [ BaseWeaponPistol, BaseSecurityContraband ] # Lust Edit :: BaseSecurityContraband
   id: WeaponPistolG22Prison
   suffix: Sunrise
   components:
@@ -265,7 +265,7 @@
     stealGroup: OfficerHandgun
 
 - type: entity
-  parent: BaseWeaponPistolSunrise
+  parent: [ BaseWeaponPistolSunrise, BaseSecurityContraband ] # Lust edit :: BaseSecurityContraband
   id: WeaponPistolM1984
   name: D1984
   description: A compact sidearm developed under Nanotrasen’s internal order directive “N1984.” A personal weapon of control, discipline, and precise response. Issued to distinguished detectives for reliability during field investigations. Fires .40 Auto.

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -157,7 +157,7 @@
 # Sidearm HOS and Nukies.
 - type: entity
   name: Desert Eagle
-  parent: BaseWeaponPistolSunrise
+  parent: [ BaseWeaponPistolSunrise, BaseSecurityContraband ] # Lust edit :: BaseSecurityContraband
   id: WeaponPistolDeagle
   components:
   - type: Sprite
@@ -213,7 +213,7 @@
 
 # Sidearm for detectives.
 - type: entity
-  parent: BaseWeaponRevolver
+  parent: [ BaseWeaponRevolver, BaseSecurityCentcommContraband ] # Lust edit :: BaseSecurityCentcommContraband
   id: WeaponRevolverSpearhead
   name: Spearhead autorevolver
   description: A bulky revolver, occasionally carried by assault troops and officers in SWAT, as well as civilian law enforcement. Fires .45 Magnum rounds. #Fires .357 Magnum rounds.

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -87,7 +87,7 @@
 
 - type: entity
   name: M16A4
-  parent: BaseWeaponRifle
+  parent: [ BaseWeaponRifle, BaseSecurityContraband ] # Lust Edit :: BaseSecurityContraband
   id: WeaponRifleM16A4
   components:
   - type: Sprite
@@ -218,7 +218,7 @@
 
 - type: entity
   name: ASH-12
-  parent: [GunLight, BaseWeaponRifle]
+  parent: [GunLight, BaseWeaponRifle, BaseSecurityCentcommContraband ] # Lust Edit :: BaseSecurityCentcommContraband
   id: WeaponRifleAsh12
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: P-90
-  parent: [ BaseWeaponSubMachineGun, BaseSecurityCentcommContraband ] # Lust edit :: BaseSecurityCentcommContraband
+  parent: [ BaseWeaponSubMachineGun, BaseSecurityContraband ] # Lust edit :: BaseSecurityContraband
   id: WeaponSubMachineGunP90
   components:
   - type: Item

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: P-90
-  parent: BaseWeaponSubMachineGun
+  parent: [ BaseWeaponSubMachineGun, BaseSecurityCentcommContraband ] # Lust edit :: BaseSecurityCentcommContraband
   id: WeaponSubMachineGunP90
   components:
   - type: Item
@@ -56,7 +56,7 @@
 
 - type: entity
   name: MP5
-  parent: BaseWeaponSubMachineGun
+  parent: [ BaseWeaponSubMachineGun, BaseSecurityContraband ] # Lust edit :: BaseSecurityContraband
   id: WeaponSubMachineGunMP5
   components:
   - type: Sprite
@@ -235,7 +235,7 @@
 
 - type: entity
   name: Lecter Mk3
-  parent: BaseWeaponSubMachineGun
+  parent: [ BaseWeaponSubMachineGun, BaseSecurityCentcommContraband ] # Lust edit :: BaseSecurityCentcommContraband
   id: WeaponRifleLecterMk3
   description: A more advanced version of Lecter.
   components:
@@ -321,7 +321,7 @@
 
 - type: entity
   name: AJ-100
-  parent: BaseWeaponSubMachineGun
+  parent: [ BaseWeaponSubMachineGun, BaseSyndicateContraband ] # Lust edit :: BaseSyndicateContraband
   id: WeaponAJ100
   description: High-speed SMG, equipped with a universal connector for other types of pistol magazines.
   components:
@@ -394,7 +394,7 @@
 
 - type: entity
   name: SIAR-52 SMG
-  parent: BaseWeaponSubMachineGun
+  parent: [ BaseWeaponSubMachineGun, BaseSyndicateContraband ] # Lust edit :: BaseSyndicateContraband
   id: WeaponSIAR52
   description: A high rate of fire weapon, equipped with integrated silencer.
   components:

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -1,6 +1,6 @@
 ﻿- type: entity
   name: Dragunov
-  parent: [ BaseWeaponRifle, BaseGunWieldable ]
+  parent: [ BaseWeaponRifle, BaseGunWieldable, BaseSovietContraband ] # Lust edit :: BaseSovietContraband
   id: WeaponSniperDragunov
   components:
   - type: Sprite
@@ -77,7 +77,7 @@
 
 - type: entity
   name: SR-127 Bauer bolt action rifle
-  parent: [ BaseWeaponRifle, BaseGunWieldable ]
+  parent: [ BaseWeaponRifle, BaseGunWieldable, BaseSyndicateContraband ] # Lust edit :: BaseSyndicateContraband
   id: WeaponRifleBauer127
   components:
   - type: Sprite
@@ -320,7 +320,7 @@
       - WrappedWeapon
 
 - type: entity
-  parent: WeaponRifleBauer127
+  parent: [ WeaponRifleBauer127, BaseSovietContraband ] # Lust edit :: BaseSovietContraband
   name: Type 88
   id: WeaponRifleType88AMR
   description: The standard issue AMR of the USSP, the Type 88 typically loaded with armor-piercing 15mm rounds in a 7 round magazine.

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -160,7 +160,7 @@
 
 - type: entity
   name: M1 Garand
-  parent: BaseItem
+  parent: [ BaseItem, BaseSecuritySalvageContraband ] # Lust edit :: BaseSecuritySalvageContraband
   id: WeaponSniperGarand
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Melee/breaching_hammer.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Melee/breaching_hammer.yml
@@ -43,7 +43,7 @@
 
 - type: entity
   name: breaching hammer
-  parent: BaseItem
+  parent: [ BaseItem, BaseSyndicateContraband ] # Lust edit :: BaseSyndicateContraband
   id: SyndieBreachingHammer
   description: A large, heavy hammer with a long handle, used for breaking stones or other heavy material such as the skulls of violent criminals, also perfect for forcing your way trough airlocks.
   components:

--- a/Resources/Prototypes/_Sunrise/Pirates/Entities/Weapons/Guns/pirate_guns.yml
+++ b/Resources/Prototypes/_Sunrise/Pirates/Entities/Weapons/Guns/pirate_guns.yml
@@ -1,6 +1,6 @@
 # region LMGs
 - type: entity
-  parent: BaseWeaponLightMachineGun
+  parent: [BaseWeaponLightMachineGun, BaseHighlyIllegalContraband] # Lust edit :: BaseHighlyIllegalContraband
   id: WeaponLightMachineGunPirateCannon
   description: Kaboom!
   components:
@@ -84,7 +84,7 @@
 - type: entity
   id: WeaponMachineGunLCG
   name: light chain gun
-  parent: BaseWeaponLightMachineGun
+  parent: [BaseWeaponLightMachineGun,BaseHighlyIllegalContraband] # Lust edit :: BaseHighlyIllegalContraband
   description: Light machine gun with a high rate of fire and low recoil. Effective for firing on the move and suppressing advancing squads. The high rate of fire and heat reduce accuracy, and prolonged firing increases the chance of jamming.
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Sunrise/Pirates/Entities/Weapons/Mechs/cannons.yml
+++ b/Resources/Prototypes/_Sunrise/Pirates/Entities/Weapons/Mechs/cannons.yml
@@ -3,7 +3,7 @@
   name: Mounted PirateCannon
   description: An ancient heavy gun given new life as a mech-mounted gun
   suffix: Mech Weapon, Gun, Combat, Pirate
-  parent: [ BaseMechWeaponRange, CombatMechEquipment ]
+  parent: [ BaseMechWeaponRange, CombatMechEquipment. BaseHighlyIllegalContraband ] # Lust edit :: BaseHighlyIllegalContraband
   components:
   - type: Sprite
     sprite: _Sunrise/Objects/Specific/Mech/mecha_piratecannon.rsi
@@ -111,7 +111,7 @@
   name: Mounted PirateGrapeshot
   description: An ancient heavy gun given new life as a mech-mounted gun
   suffix: Mech Weapon, Gun, Combat, Pirate
-  parent: [ BaseMechWeaponRange, CombatMechEquipment ]
+  parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseHighlyIllegalContraband ] # Lust edit :: BaseHighlyIllegalContraband
   components:
   - type: Sprite
     sprite: _Sunrise/Objects/Specific/Mech/mecha_blunderbuss.rsi
@@ -143,7 +143,7 @@
   name: Mounted BlunderBuss
   description: An ancient big blunderbuss gun given new life as a mech-mounted gun
   suffix: Mech Weapon, Gun, Combat, Pirate
-  parent: [ BaseMechWeaponRange, CombatMechEquipment ]
+  parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseHighlyIllegalContraband ] # Lust edit :: BaseHighlyIllegalContraband
   components:
   - type: Sprite
     sprite: _Sunrise/Objects/Specific/Mech/mecha_blunderbuss.rsi
@@ -175,7 +175,7 @@
   name: Mounted PirateGlassshot
   description: An ancient heavy gun given new life as a mech-mounted gun
   suffix: Mech Weapon, Gun, Combat, Pirate
-  parent: [ BaseMechWeaponRange, CombatMechEquipment ]
+  parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseHighlyIllegalContraband ] # Lust edit :: BaseHighlyIllegalContraband
   components:
   - type: Sprite
     sprite: _Sunrise/Objects/Specific/Mech/mecha_piratecannon.rsi

--- a/Resources/Prototypes/_Sunrise/Pirates/Entities/Weapons/Mechs/cannons.yml
+++ b/Resources/Prototypes/_Sunrise/Pirates/Entities/Weapons/Mechs/cannons.yml
@@ -3,7 +3,7 @@
   name: Mounted PirateCannon
   description: An ancient heavy gun given new life as a mech-mounted gun
   suffix: Mech Weapon, Gun, Combat, Pirate
-  parent: [ BaseMechWeaponRange, CombatMechEquipment. BaseHighlyIllegalContraband ] # Lust edit :: BaseHighlyIllegalContraband
+  parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseHighlyIllegalContraband ] # Lust edit :: BaseHighlyIllegalContraband
   components:
   - type: Sprite
     sprite: _Sunrise/Objects/Specific/Mech/mecha_piratecannon.rsi

--- a/Resources/Prototypes/_Sunrise/Research/Artifact/effects.yml
+++ b/Resources/Prototypes/_Sunrise/Research/Artifact/effects.yml
@@ -300,6 +300,17 @@
     - SupermatterCrystal
     - TeslaEnergyBall
     - TeslaMiniEnergyBall
+    # Lust edit : start
+    - FaxMachineCentcom
+    - NukeCodePaper
+    - BoxFolderNuclearCodes
+    - RubberStampVeto
+    - RubberStampRedo
+    - RubberStampMagistrat
+    - RubberStampNtrep
+    - RubberStampCentcom
+    - RubberStampSyndicate
+    # Lust edit : end
     prototypeIdBlacklistSubstrings:
     - Debug
     - Admin
@@ -308,12 +319,29 @@
     - Debug
     - Admin
     - Admeme
+    # Lust Edit : Start
+    - HL2
+    - Death Squad
+    - Qillu
+    - CentComm
+    - Central Command
+    - CentralCommand
+    - CentComm ERT
+    - ERT
+    - Uplink
+    - Arrows
+    - Event
+    # Lust Edit : End
     componentBlacklist:
     - MapGrid
     - SurgeryStep
     - SpawnPoint
     - Contraband
     - Meteor
+    # Lust Edit : Start
+    - Biocode
+    - Communications
+    # Lust Edit : End
     categoryBlacklist:
     - HideSpawnMenu
     - Debug

--- a/Resources/Prototypes/_Sunrise/Research/Artifact/effects.yml
+++ b/Resources/Prototypes/_Sunrise/Research/Artifact/effects.yml
@@ -310,6 +310,8 @@
     - RubberStampNtrep
     - RubberStampCentcom
     - RubberStampSyndicate
+    - Crematorium
+    - AgentIDCard
     # Lust edit : end
     prototypeIdBlacklistSubstrings:
     - Debug
@@ -328,9 +330,13 @@
     - CentralCommand
     - CentComm ERT
     - ERT
+    - CBURN
     - Uplink
     - Arrows
     - Event
+    - Unremoveable
+    - Filled
+    - Hardsuit
     # Lust Edit : End
     componentBlacklist:
     - MapGrid


### PR DESCRIPTION
Добавление контрабандных свойств части оружия которые их не имели из аплинка ОБР и Синдиката.
Добавлено исключение ивентовых прототипов из пула выпадения для артефакта трансформации.

**Changelog**

:cl: Matizze
- tweak: Добавление контрабандных свойств оружию, которые их раньше не имели.
:end-cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые возможности**
  * Для контрабандного оружия и экипировки уточнены ограничения по отделам и фракциям.
  * Идентификационные карты ERT и Центрального командования получили соответствующие обозначения.
  * Для некоторых комплектов одежды доступен вариант без цензуры.
* **Исправления**
  * Артефакты больше не преобразуют служебные документы, печати, средства связи и другие защищённые предметы.
  * Уточнена классификация цепных мечей, молотков, стрелкового и мех-оружия как контрабанды.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->