### PR TITLE
Фикс ERP-меню — гениталии футанари, проверки перчаток и выравнивание

### DIFF
--- a/Content.Client/_Sunrise/InteractionsPanel/InteractionsUIWindow.xaml
+++ b/Content.Client/_Sunrise/InteractionsPanel/InteractionsUIWindow.xaml
@@ -68,7 +68,8 @@
                                        MaxWidth="140"
                                        MaxHeight="40"
                                        VerticalAlignment="Top"
-                                       HorizontalAlignment="Center"
+                                       HorizontalExpand="True"
+                                       Align="Center"
                                        StyleClasses="LabelSubText">
                                 </Label>
                             </BoxContainer>
@@ -124,7 +125,8 @@
                                        MaxWidth="140"
                                        MaxHeight="40"
                                        VerticalAlignment="Top"
-                                       HorizontalAlignment="Center"
+                                       HorizontalExpand="True"
+                                       Align="Center"
                                        StyleClasses="LabelSubText">
                                 </Label>
                             </BoxContainer>

--- a/Content.Shared/_Sunrise/InteractionsPanel/Data/Conditions/Genitals.cs
+++ b/Content.Shared/_Sunrise/InteractionsPanel/Data/Conditions/Genitals.cs
@@ -33,6 +33,7 @@ public static class GenitalsHelper
             case Sex.Futanari:
                 genitals.Add(GenitalSlot.Boobs);
                 genitals.Add(GenitalSlot.Penis);
+                genitals.Add(GenitalSlot.Vagina);  // Lust edit
                 break;
             case Sex.Unsexed:
                 break;

--- a/Resources/Prototypes/_Lust/Interactions/ears.yml
+++ b/Resources/Prototypes/_Lust/Interactions/ears.yml
@@ -34,11 +34,6 @@
   - !type:HasTargetCondition
     allowSelfTargeting: false
   - !type:BodyAreaTagCondition
-    checkInitiator: true
-    checkTarget: false
-    categories: [ "ладони" ]
-    requireExposed: true
-  - !type:BodyAreaTagCondition
     checkInitiator: false
     checkTarget: true
     categories: [ "уши" ]
@@ -64,11 +59,6 @@
   appearConditions:
   - !type:HasTargetCondition
     allowSelfTargeting: false
-  - !type:BodyAreaTagCondition
-    checkInitiator: true
-    checkTarget: false
-    categories: [ "ладони" ]
-    requireExposed: true
   - !type:BodyAreaTagCondition
     checkInitiator: false
     checkTarget: true

--- a/Resources/Prototypes/_Lust/Interactions/pussy.yml
+++ b/Resources/Prototypes/_Lust/Interactions/pussy.yml
@@ -234,7 +234,7 @@
   - !type:BodyAreaTagCondition
     checkInitiator: true
     checkTarget: false
-    categories: [ "гладкие перчатки, вагина" ]
+    categories: [ "гладкие перчатки", "вагина" ]
     requireExposed: true
   interactionMessages:
   - "%user нежно ласкает пальчиками свою вагину"


### PR DESCRIPTION

<!-- Текст в стрелочках является комментариями — они не будут видны в вашем PR. -->

## Краткое описание
<!--
Что вы предлагаете изменить с помощью своего PR?
-->
Переоткрытие разбитого по сборкам PR https://github.com/makura-games/lust-station/pull/578

- Футанари: в таблицу гениталий добавлена вагина — теперь меню, подписи органов и условия интеракций согласованы с прототипами.
- Ушки: убрана проверка открытых ладоней у инициатора для EarsPat и EarsScratch — теперь можно гладить и чесать ушки в любых перчатках.
- PussySelfTouch: разделены склеенные категории "гладкие перчатки, вагина" на два элемента — проверка открытости теперь работает корректно.
- Выравнивание лейблов гениталий: HorizontalExpand + Align=Center для UserGenitalsLabel и TargetGenitalsLabel.

<!--
## TODO

Не закончили? Добавьте список того, что требуется для завершения PR'а.

- [ ] Task 1
- [ ] Task 2
-->

<!--
## Требования к картам

Если ваше изменение требует изменение на картах - опишите требования тут.
Так мапперы серверов смогут понять, как адаптировать карты под ваши изменения.


-->

**Changelog**

<!--
=== КАК ПИСАТЬ ЧЕЙНЖЛОГ ===

[Подробная инструкция и полный пример](https://github.com/makura-games/sunrise-station/blob/master/Tools/_sunrise/changelog/README.md)

1) Не считайте тип чейнжлога частью вашего предложения.
add: Новая фича = ПЛОХО | add: Добавлена новая фича = ХОРОШО
2) Подробно описывайте, что вы добавили и как это использовать. Все должно быть в меру.
fix: Исправлены мелочи = УЖАСНО | fix: Исправлена невозможность игроков двигаться = ХОРОШО
3) Не добавляйте технические детали. Чейнжлог пишется для игроков.
add: Добавлен новый хелпер-метод = ПЛОХО | НИЧЕГО НЕ ПИСАТЬ = ХОРОШО
* Иногда чейнжлог не нужен. Просто удалите это поле.

Продолжайте текст записи на следующих строках; переносы сохранятся в Discord:
`fix: Первая строка исправления`
`Вторая строка той же записи`

-->

:cl: Den_Gor
- fix: Исправлена таблица гениталий для футанари — теперь отображается вагина
- fix: Гладить и чесать ушки теперь можно в любых перчатках
- fix: Исправлена проверка открытости для ласк своей вагины в одежде
- fix: Исправлено выравнивание блока гениталий в панели взаимодействий
:end-cl:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления**
  * Улучшено центрирование подписей гениталий в панели взаимодействий.
  * Для персонажей типа «футанари» теперь корректно учитывается вагинальный слот.
  * Взаимодействия с ушами больше не требуют открытых ладоней у инициатора.
  * Исправлена проверка условий для самостоятельного прикосновения к вагине: теги перчаток и вагины обрабатываются раздельно.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->